### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.json]
+indent_style = tab


### PR DESCRIPTION
This is respected by flatpak-external-data-checker and thus prevents it
from replacing the tabs in the manifest with spaces.